### PR TITLE
Fixed parsing on leading zeros after decimal point

### DIFF
--- a/src/test/json.cpp
+++ b/src/test/json.cpp
@@ -99,6 +99,11 @@ void number_parse_tests()
     constexpr auto number_val = JSON::number_parser()("456.123e-1"sv);
     static_assert(number_val && number_val->first == 456.123e-1);
   }
+
+  {
+    constexpr auto number_val = JSON::number_parser()("0.0625"sv);
+    static_assert(number_val && number_val->first == 0.0625);
+  }
 }
 
 void numobjects_tests()


### PR DESCRIPTION
Resolves #4.

The bug occurs because the fractional part was parsed with an `int0_parser()`, which discards leading zeros. Instead, we create a `many(make_char_parser('0'), ...)` that counts the number of leading zeros, then we do another repeated division step to shift the digits into position.